### PR TITLE
fix: underflow when parsing `DerivationSeg`

### DIFF
--- a/derive/src/path.rs
+++ b/derive/src/path.rs
@@ -133,7 +133,7 @@ where
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let t = s.trim_start_matches('<').trim_end_matches('>');
-        if t.len() == s.len() - 2 {
+        if t.len() + 2 == s.len() {
             let set = t.split(';').map(I::from_str).collect::<Result<BTreeSet<_>, _>>()?;
             Ok(Self(Confined::try_from_iter(set)?))
         } else {


### PR DESCRIPTION
```bash
$ ./rgb create test1 --tapret-key-only "[9ae0796a/86h/1h/0h]tpubDDGrVg19xRy5D9x8i1ai9on1Dzn7
Pg4nTTPJw7EkPcS9rQC6w3dxHSQHH3LCfApqovuJxtzyFrAVDY86STx1eh8aERV75FRcu7wY7wH9QWp/0/*"
thread 'main' panicked at /home/_/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bp-derive-0.11.0-beta.3/src/path.rs:136:23:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

`--tapret-key-only` is obtained from `bitcoin-cli`.
Not sure if it's the correct way to create a wallet, but after fixing this panic, the wallet is created successfully.
