### PR TITLE
Fix retrieve tapret proof

### DIFF
--- a/psbt/src/csval/tapret.rs
+++ b/psbt/src/csval/tapret.rs
@@ -261,10 +261,10 @@ impl Output {
     /// Function returns generic type since the real type will create dependency
     /// on `bp-dpc` crate, which will result in circular dependency with the
     /// current crate.
-    pub fn tapret_proof(&self) -> Option<TapretPathProof> {
+    pub fn tapret_proof(&self) -> Option<TapretProof> {
         let data = self.proprietary(&PropKey::tapret_proof())?;
         let vec = Confined::try_from_iter(data.iter().copied()).ok()?;
-        TapretPathProof::from_strict_serialized::<U16>(vec).ok()
+        TapretProof::from_strict_serialized::<U16>(vec).ok()
     }
 }
 


### PR DESCRIPTION
**Description**

This PR intent fix retrieves TapRet Proof from PSBT proprietary.

**MISC**
Furthermore, it is possible to ask a question that is not directly related to PR:

How do I determine the maximum size of a strict_serialized operation? 

For example, how do I know that in tapret_proof, I use U16 instead of U24?

Thanks