### PR TITLE
Support Testnet4 Network

### DIFF
--- a/invoice/src/network.rs
+++ b/invoice/src/network.rs
@@ -40,6 +40,9 @@ pub enum Network {
     /// Bitcoin testnet
     Testnet3,
 
+    /// Bitcoin testnet4
+    Testnet4,
+
     /// Bitcoin signet
     Signet,
 
@@ -57,7 +60,7 @@ impl From<Network> for AddressNetwork {
     fn from(network: Network) -> Self {
         match network {
             Network::Mainnet => AddressNetwork::Mainnet,
-            Network::Testnet3 | Network::Signet => AddressNetwork::Testnet,
+            Network::Testnet3 | Network::Testnet4 | Network::Signet => AddressNetwork::Testnet,
             Network::Regtest => AddressNetwork::Regtest,
         }
     }
@@ -74,6 +77,7 @@ impl FromStr for Network {
         Ok(match s {
             "bitcoin" | "mainnet" => Network::Mainnet,
             "testnet" | "testnet3" => Network::Testnet3,
+            "testnet4" => Network::Testnet4,
             "signet" => Network::Signet,
             "regtest" => Network::Regtest,
             other => return Err(UnknownNetwork(other.to_owned())),


### PR DESCRIPTION
This PR introduces support for Testnet4 in the bp-invoice module. 

With the increasing data load and congestion on the Testnet3 network, the Bitcoin community is moving towards Testnet4 as a viable upgrade. 

This change includes the addition of Testnet4 as a variant in the Network type. 

Given that bp-invoice serves as the cornerstone for the BP and RGB series, updating it to support Testnet4 is crucial for the ecosystem.

If you have any suggestions, please leave your valuable comments, I will actively cooperate with the revision, thank you very much