### PR TITLE
fix: p2sh address from script

### DIFF
--- a/invoice/src/address.rs
+++ b/invoice/src/address.rs
@@ -321,7 +321,7 @@ impl AddressPayload {
             AddressPayload::Pkh(PubkeyHash::from(bytes))
         } else if script.is_p2sh() {
             let mut bytes = [0u8; 20];
-            bytes.copy_from_slice(&script[2..]);
+            bytes.copy_from_slice(&script[2..22]);
             AddressPayload::Sh(ScriptHash::from(bytes))
         } else if script.is_p2wpkh() {
             let mut bytes = [0u8; 20];


### PR DESCRIPTION
Reference: https://github.com/BP-WG/bp-core/blob/master/consensus/src/script.rs#L143-L148

the p2sh script length is 23, skip first 2 bytes, there remain 21 bytes, it will panic