### PR TITLE
Require Descriptors and DeriveKey to be Display+Clone

### DIFF
--- a/derive/src/derive.rs
+++ b/derive/src/derive.rs
@@ -22,6 +22,7 @@
 
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
+use std::fmt::Display;
 use std::num::ParseIntError;
 use std::str::FromStr;
 
@@ -356,7 +357,7 @@ pub trait Derive<D> {
     }
 }
 
-pub trait DeriveKey<D>: Derive<D> {
+pub trait DeriveKey<D>: Derive<D> + Clone + Display {
     fn xpub_spec(&self) -> &XpubAccount;
 }
 

--- a/descriptors/src/descriptor.rs
+++ b/descriptors/src/descriptor.rs
@@ -85,7 +85,7 @@ impl TaprootKeySig {
     pub fn new(key: XOnlyPk, sig: Bip340Sig) -> Self { TaprootKeySig { key, sig } }
 }
 
-pub trait Descriptor<K = XpubDerivable, V = ()>: DeriveScripts {
+pub trait Descriptor<K = XpubDerivable, V = ()>: DeriveScripts + Clone + Display {
     fn class(&self) -> SpkClass;
     #[inline]
     fn is_taproot(&self) -> bool { self.class().is_taproot() }

--- a/descriptors/src/segwit.rs
+++ b/descriptors/src/segwit.rs
@@ -98,6 +98,6 @@ impl<K: DeriveCompr> Descriptor<K> for Wpkh<K> {
     }
 }
 
-impl<K: DeriveCompr + Display> Display for Wpkh<K> {
+impl<K: DeriveCompr> Display for Wpkh<K> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result { write!(f, "wpkh({})", self.0) }
 }

--- a/descriptors/src/taproot.rs
+++ b/descriptors/src/taproot.rs
@@ -100,7 +100,7 @@ impl<K: DeriveXOnly> Descriptor<K> for TrKey<K> {
     }
 }
 
-impl<K: DeriveXOnly + Display> Display for TrKey<K> {
+impl<K: DeriveXOnly> Display for TrKey<K> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result { write!(f, "tr({})", self.0) }
 }
 


### PR DESCRIPTION
This is generally needed in wallets downstream; without it we need to put this generic bounds nearly everywhere, which pollutes the code