### PR TITLE
fix nightly build, lint and manifest for wasm-testing

### DIFF
--- a/derive/src/xkey.rs
+++ b/derive/src/xkey.rs
@@ -642,7 +642,7 @@ impl XkeyOrigin {
         self.derivation.iter().copied().map(DerivationIndex::from).collect()
     }
 
-    pub fn child_derivation<'a>(&'a self, child: &'a KeyOrigin) -> Option<&[DerivationIndex]> {
+    pub fn child_derivation<'a>(&'a self, child: &'a KeyOrigin) -> Option<&'a [DerivationIndex]> {
         if self.master_fp() == child.master_fp() {
             let d = child.derivation();
             let shared = d.shared_prefix(self.derivation());

--- a/descriptors/Cargo.toml
+++ b/descriptors/Cargo.toml
@@ -6,7 +6,7 @@ keywords = { workspace = true }
 categories = { workspace = true }
 readme = "../README.md"
 authors = { workspace = true }
-homepage = { workspace = true }
+homepage.workspace = true
 repository = { workspace = true }
 rust-version = { workspace = true }
 edition = { workspace = true }

--- a/psbt/Cargo.toml
+++ b/psbt/Cargo.toml
@@ -6,7 +6,7 @@ keywords = { workspace = true }
 categories = { workspace = true }
 readme = "../README.md"
 authors = { workspace = true }
-homepage = { workspace = true }
+homepage.workspace = true
 repository = { workspace = true }
 rust-version = { workspace = true }
 edition = { workspace = true }

--- a/psbt/src/coders.rs
+++ b/psbt/src/coders.rs
@@ -185,7 +185,7 @@ pub trait Encode {
     fn encode(&self, writer: &mut dyn Write) -> Result<usize, IoError>;
 }
 
-impl<'a, T: Encode> Encode for &'a T {
+impl<T: Encode> Encode for &'_ T {
     fn encode(&self, writer: &mut dyn Write) -> Result<usize, IoError> { (*self).encode(writer) }
 }
 
@@ -677,7 +677,7 @@ macro_rules! psbt_code_using_consensus {
 }
 
 struct WriteWrap<'a>(&'a mut dyn Write);
-impl<'a> Write for WriteWrap<'a> {
+impl Write for WriteWrap<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> { self.0.write(buf) }
     fn flush(&mut self) -> io::Result<()> { self.0.flush() }
 }

--- a/psbt/src/data.rs
+++ b/psbt/src/data.rs
@@ -1041,7 +1041,7 @@ impl Output {
         if terminal.len() != 1 {
             return None;
         }
-        return terminal.first().copied();
+        terminal.first().copied()
     }
 }
 

--- a/src/signers.rs
+++ b/src/signers.rs
@@ -80,7 +80,7 @@ impl<'a> TestnetRefSigner<'a> {
     }
 }
 
-impl<'a> Signer for TestnetRefSigner<'a> {
+impl Signer for TestnetRefSigner<'_> {
     type Sign<'s>
         = Self
     where Self: 's;
@@ -88,7 +88,7 @@ impl<'a> Signer for TestnetRefSigner<'a> {
     fn approve(&self, _: &Psbt) -> Result<Self::Sign<'_>, Rejected> { Ok(self.clone()) }
 }
 
-impl<'a> TestnetRefSigner<'a> {
+impl TestnetRefSigner<'_> {
     fn get(&self, origin: Option<&KeyOrigin>) -> Option<Xpriv> {
         let origin = origin?;
         self.keys.iter().find_map(|(xo, xpriv)| {
@@ -100,7 +100,7 @@ impl<'a> TestnetRefSigner<'a> {
     }
 }
 
-impl<'a> Sign for TestnetRefSigner<'a> {
+impl Sign for TestnetRefSigner<'_> {
     fn sign_ecdsa(
         &self,
         message: Sighash,


### PR DESCRIPTION
This PR fixes the build on nightly. @dr-orlovsky I have used 0.11 beta 9 as base for the commit and would be glad if you could release a beta 9.1 for this (it would fix the new CI job added in https://github.com/RGB-WG/rgb-tests/pull/25)