### PR TITLE
Fix TrKey taproot_witness for key path spending

### DIFF
--- a/descriptors/src/tr.rs
+++ b/descriptors/src/tr.rs
@@ -237,7 +237,10 @@ impl<K: DeriveXOnly> Descriptor<K> for TrKey<K> {
         cb: Option<&ControlBlock>,
         keysigs: IndexMap<&KeyOrigin, TaprootKeySig>,
     ) -> Option<Witness> {
-        cb?;
+        if cb.is_some() {
+            // TrKey doesn't support script path spending
+            return None;
+        }
         let our_origin = self.0.xpub_spec().origin();
         let keysig =
             keysigs.iter().find(|(origin, _)| our_origin.is_subset_of(origin)).map(|(_, ks)| ks)?;


### PR DESCRIPTION

### Summary
This PR fixes a critical bug in the `TrKey::taproot_witness()` method that prevents proper PSBT finalization for Taproot key path spending.

### Problem
The current implementation in `bp-std/descriptors/src/tr.rs` at line 240 contains an incorrect early return:

```rust
fn taproot_witness(
    &self,
    cb: Option<&ControlBlock>,
    keysigs: HashMap<&KeyOrigin, TaprootKeySig>,
) -> Option<Witness> {
    cb?; 
    // ...
}
```

The `cb?;` statement causes the function to return `None` when `cb` is `None`, but for Taproot key path spending, `cb` **should** be `None`. This results in:

1. PSBT signing succeeds and collects signatures
2. PSBT finalization fails because `taproot_witness()` returns `None`
3. Transaction extraction fails with `UnfinalizedInputs` error

### Root Cause
The logic is inverted. For `TrKey` (key-only Taproot descriptor):
- When `cb` is `None` → **Key path spending** → Should create witness 
- When `cb` is `Some` → **Script path spending** → Not supported, should return `None` 